### PR TITLE
wandb upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PyYAML==5.3.1
 click==8.0.3
-wandb==0.12.7
+wandb>=0.12.18
 py-cpuinfo==8.0.0
 docker==5.0.3
 pandas==1.3.4


### PR DESCRIPTION
With wandb==0.12.7, we have to downgrade protobuf: 
protobuf 4.21.1 -> protobuf 3.20.x

Issue solved for wandb>=0.12.18